### PR TITLE
Plone 4.3 compatibility: fix interfaces in dexterity.zcml

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ Changelog
 1.5.1 (unreleased)
 ------------------
 
+- Dexterity: use zope.lifecycleevent instead of zope.app.container
+  interfaces for Plone 4.3 support.
+  [jone]
+
 - Avoid a bug during link integrity check when a source or target of the
   reference has been already removed during the deletion process.
   This can happen during large delete processes.

--- a/plone/app/linkintegrity/dexterity.zcml
+++ b/plone/app/linkintegrity/dexterity.zcml
@@ -24,7 +24,7 @@
 
   <subscriber
     for="plone.app.referenceablebehavior.referenceable.IReferenceable
-         zope.app.container.interfaces.IObjectRemovedEvent"
+         zope.lifecycleevent.interfaces.IObjectRemovedEvent"
     handler=".handlers.referencedObjectRemoved" />
 
 </configure>


### PR DESCRIPTION
Plone 4.3 no longer includes `zope.app.container`, so we need to use `zope.lifecycleevent`.
