### PR TITLE
Ignore malformed links when retrieving objects

### DIFF
--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -103,7 +103,10 @@ def getObjectsFromLinks(base, links):
     url = base.absolute_url()
     scheme, host, path, query, frag = urlsplit(url)
     for link in links:
-        s, h, path, q, f = urlsplit(link)
+        try:
+            s, h, path, q, f = urlsplit(link)
+        except ValueError:
+            continue
         if (not s and not h) or (s == scheme and h == host):    # relative or local url
             obj, extra = findObject(base, path)
             if obj:
@@ -131,7 +134,7 @@ def modifiedArchetype(obj, event):
         # to `reference_catalog`
         return
     refs = set()
-    
+
     for field in obj.Schema().fields():
         if isinstance(field, TextField):
             accessor = field.getAccessor(obj)


### PR DESCRIPTION
The getObjectsFromLinks receives a list of links, to determine which of those are local 
to the Plone install - and do retrieve the objects for those it finds to be local.

However, since it does the link selection on its own, its callers don't need to 
verify each link of the links passed for integrity (and they will often come
from content input by the user). 

This check prevents a ValueError from malformed links to abort the retrieval, and from
propagating to the caller. 

(In my use, this exception just aborted an import of 1000's of content items into Plone using transmogrifier)
