### PR TITLE
Do not loose references when calling at_download script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.5.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Keep reference integrity  also for URLs that are calling ``FSPythonScript``
+  (like ``...atfile/at_download/file``)
+  [keul]
 
 
 1.5.4 (2014-01-27)

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -8,7 +8,7 @@ from zope.schema import getFieldsInOrder
 from Products.CMFCore.utils import getToolByName
 from Products.Archetypes.interfaces import IReference
 from Products.Archetypes.Field import TextField
-from OFS.interfaces import IItem
+from Products.CMFCore.interfaces import IContentish
 from zExceptions import NotFound
 from ZODB.POSException import ConflictError
 from zope.component.hooks import getSite
@@ -94,7 +94,7 @@ def findObject(base, path):
         except (AttributeError, KeyError,
                 NotFound, ztkNotFound, UnicodeEncodeError):
             return None, None
-        if not IItem.providedBy(child):
+        if not IContentish.providedBy(child):
             break
         obj = child
         components.pop(0)


### PR DESCRIPTION
The problem: references to file subpath make the reference engine to fail (reference lost or not created). The simplest example is an URL that call `http://plone/path/to/atfile/at_download/file`.

@hoka already fixed this issue in version 1.5.4, but his fix is not working for me because, even if resolveUID is used, the HTML catch by the reference engine is already transformed by outputfilters.
The problem is that `FSPythonScript` (like `at_download` is on Plone 4) implements the `IItem` interface.
