### PR TITLE
Keep reference integrity also for URLs that are calling FSPythonScript

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Changelog
   TestCases.
   [saily, do3cc]
 
+- Keep reference integrity also for URLs that are calling ``FSPythonScript``
+  (like ``...atfile/at_download/file``)
 
 2.0.0 (2014-04-13)
 ------------------

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -6,7 +6,7 @@ from Products.Archetypes.interfaces import IBaseObject
 from Products.Archetypes.interfaces import IReference
 from Products.Archetypes.interfaces import IReferenceable
 from Products.CMFCore.utils import getToolByName
-from OFS.interfaces import IItem
+from Products.CMFCore.interfaces import IContentish
 from ZODB.POSException import ConflictError
 from plone.app.linkintegrity.exceptions \
     import LinkIntegrityNotificationException
@@ -91,7 +91,7 @@ def findObject(base, path):
         except (AttributeError, KeyError,
                 NotFound, ztkNotFound, UnicodeEncodeError):
             return None, None
-        if not IItem.providedBy(child):
+        if not IContentish.providedBy(child): 
             break
         obj = child
         components.pop(0)


### PR DESCRIPTION
See https://github.com/plone/plone.app.linkintegrity/pull/12

Probably I've not finished, as issue #12 was also tested. I can add test here? If master is used on Plone 5 I have not at_download available, isn't it?
Any suggestion?
