### PR TITLE
Make findObject work if the webserver rewrites the portal name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ New:
 Fixes:
 
 - *add item here*
-
+- make handler.findObject() work when the webserver rewrites the portal name
+  [tschorr]
 
 1.5.7 (2015-11-17)
 ------------------

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -65,7 +65,7 @@ def findObject(base, path):
     if path.startswith('/'):
         # Make an absolute path relative to the portal root
         obj = getToolByName(base, 'portal_url').getPortalObject()
-        portal_path = '/'.join(obj.getPhysicalPath()) + '/'
+        portal_path = obj.absolute_url_path() + '/'
         if path.startswith(portal_path):
             path = path[len(portal_path):]
         else:

--- a/plone/app/linkintegrity/tests/test_handlers.py
+++ b/plone/app/linkintegrity/tests/test_handlers.py
@@ -23,3 +23,14 @@ class FindObjectTests(PloneTestCase.PloneTestCase):
         obj, components = findObject(self.portal.doc1, '/doc2')
         self.assertEqual(obj.absolute_url_path(), '/plone/doc2')
         self.assertEqual(components, '')
+
+    def test_webserver_rewrites_portal_name(self):
+        # test the case where a webserver rewrites the portal name, e.g. for Apache:
+        # RewriteRule ^/wssitename(.*)$ http://localhost:8080/VirtualHostBase/http/my.domain.com:80/plonesitename/VirtualHostRoot/_vh_wssitename$1
+        self.portal.REQUEST.other['VirtualRootPhysicalPath'] = ('', 'plone')
+        self.portal.REQUEST._script = ['plone_foo']
+        obj, components = findObject(self.portal.doc1, '/plone_foo/doc2')
+        self.assertEqual(obj.absolute_url_path(), '/plone_foo/doc2')
+        self.assertEqual(obj.getPhysicalPath(), ('','plone', 'doc2'))
+        self.assertEqual(components, '')
+


### PR DESCRIPTION
This is similar to the problem described in #28. `handlers.findObject` cannot find an object if the webserver rewrites the portal name because it uses getPhysicalPath to lookup the portal. The proposed fix is very similar to the suggestion in #28 and should also fix that issue.