### PR TITLE
Make findObject work if the webserver rewrites the portal name (master)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ Fixes:
   upgrade issues.
   [vangheem]
 
+- make handler.findObject() work when the webserver rewrites the portal name
+  [tschorr]
+
 
 3.0.3 (2015-11-26)
 ------------------

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -30,7 +30,7 @@ def findObject(base, path):
     if path.startswith('/'):
         # Make an absolute path relative to the portal root
         obj = getToolByName(base, 'portal_url').getPortalObject()
-        portal_path = '/'.join(obj.getPhysicalPath()) + '/'
+        portal_path = obj.absolute_url_path() + '/'
         if path.startswith(portal_path):
             path = path[len(portal_path):]
     else:

--- a/plone/app/linkintegrity/tests/test_handlers.py
+++ b/plone/app/linkintegrity/tests/test_handlers.py
@@ -1,0 +1,35 @@
+from plone.app.linkintegrity.tests.base import ATBaseTestCase
+from plone.app.linkintegrity.tests.base import DXBaseTestCase
+from plone.app.linkintegrity.handlers import findObject
+
+
+class FindObjectTests:
+    """ testing the handlers.findObject function """
+    
+    def test_relative_to_portal_root_1(self):
+        obj, components = findObject(self.portal.doc1, '/plone/doc2')
+        self.assertEqual(obj.absolute_url_path(), '/plone/doc2')
+        self.assertEqual(components, '')
+
+    def test_relative_to_portal_root_2(self):
+        # Prevent regression. See https://github.com/plone/plone.app.linkintegrity/pull/17
+        obj, components = findObject(self.portal.doc1, '/doc2')
+        self.assertEqual(obj.absolute_url_path(), '/plone/doc2')
+        self.assertEqual(components, '')
+
+    def test_webserver_rewrites_portal_name(self):
+        # test the case where a webserver rewrites the portal name, e.g. for Apache:
+        # RewriteRule ^/wssitename(.*)$ http://localhost:8080/VirtualHostBase/http/my.domain.com:80/plonesitename/VirtualHostRoot/_vh_wssitename$1
+        self.portal.REQUEST.other['VirtualRootPhysicalPath'] = ('', 'plone')
+        self.portal.REQUEST._script = ['plone_foo']
+        obj, components = findObject(self.portal.doc1, '/plone_foo/doc2')
+        self.assertEqual(obj.absolute_url_path(), '/plone_foo/doc2')
+        self.assertEqual(obj.getPhysicalPath(), ('','plone', 'doc2'))
+        self.assertEqual(components, '')
+
+class ReferenceGenerationDXTestCase(DXBaseTestCase, FindObjectTests):
+    """findObject testcase for dx content types"""
+
+
+class ReferenceGenerationATTestCase(ATBaseTestCase, FindObjectTests):
+    """findObject testcase for at content types"""


### PR DESCRIPTION
As requested by pbauer, same as #34 but for master.