### PR TITLE
Use transaction savepoints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Use transaction savepoints while calling @@updateLinkIntegrityInformation
+  to keep memory usage under control.
+  [ale-rt]
 
 
 3.0.6 (2016-08-17)


### PR DESCRIPTION
Use transaction savepoints while calling the view ``@@updateLinkIntegrityInformation`` to keep memory usage under control.