### PR TITLE
remove hard dependency on Archetypes (again)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug fixes:
 - Add coding headers on python files.
   [gforcada]
 
+- Remove hard dependency on Archetypes (again).
+  [davisagli]
+
 
 3.0.7 (2016-09-16)
 ------------------

--- a/plone/app/linkintegrity/compat.py
+++ b/plone/app/linkintegrity/compat.py
@@ -3,7 +3,7 @@
 
 try:
     from Products.Archetypes.interfaces import IBaseObject
-    from Products.Archtypes.Field import TextField
+    from Products.Archetypes.Field import TextField
 except ImportError:
     from zope.interface import Interface
 

--- a/plone/app/linkintegrity/compat.py
+++ b/plone/app/linkintegrity/compat.py
@@ -1,0 +1,14 @@
+# If Archetypes is not installed, define dummy objects
+# to replace Archetypes imports.
+
+try:
+    from Products.Archetypes.interfaces import IBaseObject
+    from Products.Archtypes.Field import TextField
+except ImportError:
+    from zope.interface import Interface
+
+    class IBaseObject(Interface):
+        pass
+
+    class TextField(object):
+        pass

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_get
 from Acquisition import aq_parent
-from Products.Archetypes.interfaces import IBaseObject
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IPloneSiteRoot
 from ZODB.POSException import ConflictError
@@ -19,6 +18,7 @@ from zope.component.interfaces import ComponentLookupError
 from zope.intid.interfaces import IIntIds
 from zope.keyreference.interfaces import NotYet
 from zope.publisher.interfaces import NotFound as ztkNotFound
+from .compat import IBaseObject
 import logging
 
 logger = logging.getLogger(__name__)

--- a/plone/app/linkintegrity/retriever.py
+++ b/plone/app/linkintegrity/retriever.py
@@ -5,14 +5,14 @@ from plone.app.linkintegrity.interfaces import IRetriever
 from plone.app.linkintegrity.parser import extractLinks
 from zope.component import adapter
 from zope.interface import implementer
-from Products.Archetypes.Field import TextField
-from Products.Archetypes.interfaces import IBaseObject
 from plone.dexterity.interfaces import IDexterityContent
 from zope.component import getUtility
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.utils import getAdditionalSchemata
 from zope.schema import getFieldsInOrder
 from plone.app.textfield import RichText
+from .compat import IBaseObject
+from .compat import TextField
 
 
 @implementer(IRetriever)


### PR DESCRIPTION
This makes it possible to start Plone without Archetypes if you install just Products.CMFPlone instead of Plone.