### PR TITLE
Don't check if dexterity is present 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 1.5.9 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Don't check if dexterity is present by importing from plone.directives, grok
+  is no longer part of dexterity.
+  [fredvd]
+
 
 
 1.5.8 (2016-02-02)

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -41,7 +41,6 @@ try:
     from plone.app.textfield import RichText
     from plone.dexterity.interfaces import IDexterityFTI
     from plone.dexterity.utils import getAdditionalSchemata
-    from plone.directives.form import Schema
     HAS_DEXTERITY = True
 except:
     HAS_DEXTERITY = False


### PR DESCRIPTION
by importing from plone.directives, grok is no longer part of dexterity.