### PR TITLE
check any reference in delete confirmation dialog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Support for any ``zc.relation`` refercences being checked by ``delete_confirmation_info`` dialog,
+  not only references linked in text.
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/linkintegrity/browser/info.py
+++ b/plone/app/linkintegrity/browser/info.py
@@ -146,7 +146,7 @@ class DeleteConfirmationInfo(BrowserView):
         Breaches originating from excluded_path are ignored.
         """
         breaches = {}
-        direct_links = getIncomingLinks(obj)
+        direct_links = getIncomingLinks(obj, from_attribute=None)
         has_breaches = False
         for direct_link in direct_links:
             source_path = direct_link.from_path

--- a/plone/app/linkintegrity/utils.py
+++ b/plone/app/linkintegrity/utils.py
@@ -7,15 +7,20 @@ from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
 
 
-def getIncomingLinks(obj=None, intid=None):
+def getIncomingLinks(
+    obj=None,
+    intid=None,
+    from_attribute=referencedRelationship
+):
     """Return a generator of incoming relations created using
     plone.app.linkintegrity (Links in Richtext-Fields).
     """
     catalog = getUtility(ICatalog)
     intid = intid if intid is not None else getUtility(IIntIds).getId(obj)
-    return catalog.findRelations({
-        'to_id': intid,
-        'from_attribute': referencedRelationship})
+    query = {'to_id': intid}
+    if from_attribute:
+        query['from_attribute'] = from_attribute
+    return catalog.findRelations(query)
 
 
 def hasIncomingLinks(obj=None, intid=None):
@@ -29,15 +34,20 @@ def hasIncomingLinks(obj=None, intid=None):
     return False
 
 
-def getOutgoingLinks(obj=None, intid=None):
+def getOutgoingLinks(
+    obj=None,
+    intid=None,
+    from_attribute=referencedRelationship
+):
     """Return a generator of outgoing relations created using
     plone.app.linkintegrity (Links in Richtext-Fields).
     """
     catalog = getUtility(ICatalog)
     intid = intid if intid is not None else getUtility(IIntIds).getId(obj)
-    return catalog.findRelations({
-        'from_id': intid,
-        'from_attribute': referencedRelationship})
+    query = {'from_id': intid}
+    if from_attribute:
+        query['from_attribute'] = from_attribute
+    return catalog.findRelations(query)
 
 
 def hasOutgoingLinks(obj=None, intid=None):


### PR DESCRIPTION
Support for any ``zc.relation`` refercences being checked by ``delete_confirmation_info`` dialog, not only references linked in text.

/cc @jensens @mauritsvanrees 