### PR TITLE
Fix a missing tal condition in delete_confirmation_info.pt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix a missing tal condition in `delete_confirmation_info.pt` that caused a
+  paragraph to be always visible, even without link breaches.
+  [arsenico13]
 
 
 3.3.2 (2017-08-14)

--- a/plone/app/linkintegrity/browser/delete_confirmation_info.pt
+++ b/plone/app/linkintegrity/browser/delete_confirmation_info.pt
@@ -76,7 +76,7 @@
 
       </div>
 
-      <p i18n:translate="linkintegrity_delete_anyway">
+      <p tal:condition="breaches" i18n:translate="linkintegrity_delete_anyway">
         Would you like to delete it anyway?
       </p>
 


### PR DESCRIPTION
In the template "delete_confirmation_info.pt" there was a paragraph without a tal:condition.
That caused to show always the message, even without link breaches.