### PR TITLE
Optimize migration of old Archetypes references

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Optimize migration of old Archetypes references.
+  [davisagli]
 
 
 3.3.3 (2017-10-02)

--- a/README.rst
+++ b/README.rst
@@ -99,12 +99,12 @@ To check items for links in html-fields you can use the methods in
 
 ``utils.getIncomingLinks(obj, from_attribute)``
     Return a generator of incoming relations.
-    ``from_attribute`` is optional and defaults to ``plone.app.linkintegrity.handlers.referencedRelationship``.
+    ``from_attribute`` is optional and defaults to ``plone.app.linkintegrity.utils.referencedRelationship``.
     Is set to None, all references pointing to the object are searched.
 
 ``utils.getOutgoingLinks(obj, from_attribute)``
     Return a generator of outgoing relations.
-    ``from_attribute`` is optional and defaults to ``plone.app.linkintegrity.handlers.referencedRelationship``.
+    ``from_attribute`` is optional and defaults to ``plone.app.linkintegrity.utils.referencedRelationship``.
     Is set to None, all references pointing from the object are searched.
 
 ``utils.linkintegrity_enabled()``

--- a/plone/app/linkintegrity/tests/test_upgrade.py
+++ b/plone/app/linkintegrity/tests/test_upgrade.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from plone.app.linkintegrity.handlers import referencedRelationship
 from plone.app.linkintegrity.tests.base import ATBaseTestCase
 from plone.app.linkintegrity.upgrades import migrate_linkintegrity_relations
 from plone.app.linkintegrity.utils import hasIncomingLinks
+from plone.app.linkintegrity.utils import referencedRelationship
 try:
     from Products.Archetypes.interfaces import IReferenceable
     HAS_AT = True


### PR DESCRIPTION
This changes the approach for migrating Archetypes references to the relation catalog, and makes it run faster. On one large site (~300k items) this makes the migration run for us in 20 minutes instead of multiple hours.

The old code looped over the references in the reference_catalog and triggered the modified event on the source and target objects to make the linkintegrity event handlers scan for links and add them to the relation catalog. This has multiple problems:
- It triggers a portal_catalog reindex of the source and target objects which isn't necessary.
- It updates the modified time of the source and target.
- It spends time scanning for links even though we can already look up the existing links easily in the reference_catalog.
- It scans the target object for no reason that I can see.
- It does these things while looping over references. So if an object is the source or target of multiple references, it will be reindexed and its relations replaced multiple times, once for each reference!

The new approach is to directly add a relation to the zc.relation catalog for each one that exists in the reference_catalog without rescanning the links.