### PR TITLE
Fix ${DYNAMIC_CONTENT} in translation files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Mark strings in delete confirmation screen translatable
+  [erral]
 
 
 3.3.4 (2018-02-04)

--- a/plone/app/linkintegrity/browser/delete_confirmation_info.pt
+++ b/plone/app/linkintegrity/browser/delete_confirmation_info.pt
@@ -64,7 +64,7 @@
               <strong><span tal:replace="content" i18n:name="content" /></strong>  will also be deleted:
             </span><br/>
             <ul>
-              <li tal:define="objects python:['Objects in all', 'Folders', 'Published objects'] "
+              <li tal:define="objects view/objects"
                   tal:repeat="item python:range(3) "
                   i18n:translate="">
                 <span tal:replace="python: breach_count[content][item]" />

--- a/plone/app/linkintegrity/browser/info.py
+++ b/plone/app/linkintegrity/browser/info.py
@@ -7,11 +7,11 @@ from plone.uuid.interfaces import IUUID
 from Products.CMFCore.permissions import AccessContentsInformation
 from Products.CMFCore.utils import _checkPermission
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone import PloneMessageFactory as _
 from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
-
 import logging
 
 
@@ -191,3 +191,6 @@ class DeleteConfirmationInfo(BrowserView):
 
     def is_accessible(self, obj):
         return _checkPermission(AccessContentsInformation, obj)
+
+    def objects(self):
+        return [_('Objects in all'), _('Folders'), _('Published objects')]


### PR DESCRIPTION
Make "Delete Folder" screen messages translatable and avoid ${DYNAMIC_CONTENT} to be in PO files.