### PR TITLE
Explicitly load zcml of dependencies.

### DIFF
--- a/news/2952.bugfix
+++ b/news/2952.bugfix
@@ -1,0 +1,2 @@
+Explicitly load zcml of dependencies, instead of using ``includeDependencies``.
+[maurits]

--- a/plone/app/linkintegrity/configure.zcml
+++ b/plone/app/linkintegrity/configure.zcml
@@ -4,7 +4,8 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:zcml="http://namespaces.zope.org/zcml">
 
-  <includeDependencies package="." />
+  <include package="plone.app.intid" />
+  <include package="plone.app.relationfield" />
   <include package="Products.CMFCore" file="permissions.zcml" />
 
   <include package=".browser" />


### PR DESCRIPTION
This is instead of using includeDependencies.

See https://github.com/plone/Products.CMFPlone/issues/2952