### PR TITLE
Fix Unauthorized when editing page with link to page you cannot see.

### DIFF
--- a/news/79.bugfix
+++ b/news/79.bugfix
@@ -1,0 +1,3 @@
+Fix Unauthorized exception when you edit a page that links to another page that you are not allowed to see.
+Fixes `issue 79 <https://github.com/plone/plone.app.linkintegrity/issues/79>`_.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.linkintegrity/issues/79.

```
http://localhost:8080/Plone/pageb/@@edit
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.edit, line 58, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 145, in update
  Module plone.app.z3cform.csrf, line 22, in execute
  Module z3c.form.action, line 98, in execute
  Module z3c.form.button, line 315, in __call__
  Module z3c.form.button, line 170, in __call__
  Module plone.dexterity.browser.edit, line 30, in handleApply
  Module z3c.form.group, line 126, in applyChanges
  Module zope.event, line 32, in notify
  Module zope.component.event, line 27, in dispatch
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module zope.component.event, line 36, in objectEventNotify
  Module zope.component._api, line 134, in subscribers
  Module zope.interface.registry, line 448, in subscribers
  Module zope.interface.adapter, line 619, in subscribers
  Module plone.app.linkintegrity.handlers, line 109, in modifiedContent
  Module plone.app.linkintegrity.handlers, line 89, in getObjectsFromLinks
  Module plone.app.linkintegrity.handlers, line 49, in findObject
  Module plone.app.uuid.utils, line 39, in uuidToObject
  Module Products.ZCatalog.CatalogBrains, line 91, in getObject
  Module OFS.Traversable, line 360, in restrictedTraverse
  Module OFS.Traversable, line 292, in unrestrictedTraverse
   - __traceback_info__: ([], 'pagea')
Unauthorized: You are not allowed to access 'pagea' in this context
```