### PR TITLE
Use base64.decodebytes instead of decodestring when possible.

### DIFF
--- a/news/81.bugfix
+++ b/news/81.bugfix
@@ -1,0 +1,3 @@
+Use base64.decodebytes instead of decodestring when possible.
+Fixes Python 3.9 compatibility in the tests.
+[maurits]

--- a/plone/app/linkintegrity/testing.py
+++ b/plone/app/linkintegrity/testing.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from base64 import decodestring
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE  # noqa
 from plone.app.testing import layers
@@ -17,9 +16,15 @@ from zope.configuration import xmlconfig
 
 import six
 
+try:
+    from base64 import decodebytes
+except ImportError:
+    # BBB for Python 2
+    from base64 import decodestring as decodebytes
+
 
 B64_DATA = b'R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs='
-GIF = six.BytesIO(decodestring(B64_DATA))
+GIF = six.BytesIO(decodebytes(B64_DATA))
 GIF.filename = 'sample.gif'
 GIF.contentType = 'image/gif'
 GIF._width = 1


### PR DESCRIPTION
Fixes Python 3.9 compatibility in the tests.