### PR TITLE
Track links from <source src=> tag attributes as well

### DIFF
--- a/news/77.feature
+++ b/news/77.feature
@@ -1,0 +1,1 @@
+* Track integrity of video and audio files in HTML source tags.

--- a/plone/app/linkintegrity/parser.py
+++ b/plone/app/linkintegrity/parser.py
@@ -32,6 +32,7 @@ class LinkParser(HTMLParser):
             self.links.extend(search_attr('src', attrs))
         if tag == 'source':
             self.links.extend(search_attr('src', attrs))
+            self.links.extend(search_attr('srcset', attrs))
 
 
 def search_attr(name, attrs):

--- a/plone/app/linkintegrity/parser.py
+++ b/plone/app/linkintegrity/parser.py
@@ -30,6 +30,8 @@ class LinkParser(HTMLParser):
             self.links.extend(search_attr('href', attrs))
         if tag == 'img':
             self.links.extend(search_attr('src', attrs))
+        if tag == 'source':
+            self.links.extend(search_attr('src', attrs))
 
 
 def search_attr(name, attrs):


### PR DESCRIPTION
This alerts the user to deletion of videos and sound recordings that are used somewhere else in the portal.

Ought to fix #77.