### PR TITLE
Track integrity of IFRAME SRC= too.

### DIFF
--- a/news/84.feature
+++ b/news/84.feature
@@ -1,0 +1,1 @@
+Track link integrity of referenced PDFs and other site objects in IFRAME SRC references.

--- a/plone/app/linkintegrity/parser.py
+++ b/plone/app/linkintegrity/parser.py
@@ -10,60 +10,59 @@ except ImportError as e:
         pass
 
 
+TAG_ATTRS_TO_TRACK = {
+    # The humble hyperlink.
+    "a": ["href"],
+    # The image.
+    "img": ["src", "srcset"],
+    # Used within img/picture/audio/video tags
+    # to embed various sources of media.
+    "source": ["src", "srcset"],
+    # Embeds audio recordings.
+    "audio": ["src"],
+    # Embeds videos.
+    "video": ["src"],
+    # Used to embed PDFs.
+    "iframe": ["src"],
+}
+
+
 class LinkParser(HTMLParser):
-    """A simple html parser for link and image urls.
-    """
+    """A simple html parser for link and image urls."""
 
     def __init__(self):
         HTMLParser.__init__(self)
         self.links = []
 
     def getLinks(self):
-        """Return all links found during parsing.
-        """
+        """Return all links found during parsing."""
         return tuple(self.links)
 
     def handle_starttag(self, tag, attrs):
-        """Override the method to remember all links.
-        """
-        if tag == 'a':
-            self.links.extend(search_attr('href', attrs))
-        if tag == 'img':
-            self.links.extend(search_attr('src', attrs))
-            self.links.extend(search_attr('srcset', attrs))
-        if tag == 'source':
-            # Used within img/picture/audio/video tags
-            # to embed various sources of media.
-            self.links.extend(search_attr('src', attrs))
-            self.links.extend(search_attr('srcset', attrs))
-        if tag == 'audio':
-            # Embeds audio recordings.
-            self.links.extend(search_attr('src', attrs))
-        if tag == 'video':
-            # Embeds videos.
-            self.links.extend(search_attr('src', attrs))
-        if tag == 'iframe':
-            # Used to embed PDFs.
-            self.links.extend(search_attr('src', attrs))
+        """Override the method to remember all links."""
+        for at in TAG_ATTRS_TO_TRACK.get(tag.lower(), []):
+            self.links.extend(search_attr(at), attrs)
+
+
+def links_in_srcset(attrval):
+    # SRCSET is split by commas, and each line's first
+    # element is the URL in question.
+    # Yes, this means that spaces in such a link must be
+    # encoded with %20 or +.  That is what the written
+    # standard implies.
+    return [src.strip().split()[0] for src in attrval.split(",")]
 
 
 def search_attr(name, attrs):
-    """Search named attribute in a list of attributes.
-    """
+    """Search named attribute in a list of attributes."""
     for attr, value in attrs:
         if attr == name:
-            if name == "srcset":
-                # SRCSET is split by commas, and each line's first
-                # element is the URL in question.
-                return [src.strip().split()[0] for src in value.split(",")]
-            else:
-                return [value]
+            return links_in_srcset(value) if name == "srcset" else [value]
     return []
 
 
-def extractLinks(data, encoding='utf-8'):
-    """Parse the given html and return all links.
-    """
+def extractLinks(data, encoding="utf-8"):
+    """Parse the given html and return all links."""
     if not data:
         return []
     parser = LinkParser()

--- a/plone/app/linkintegrity/parser.py
+++ b/plone/app/linkintegrity/parser.py
@@ -41,7 +41,7 @@ class LinkParser(HTMLParser):
     def handle_starttag(self, tag, attrs):
         """Override the method to remember all links."""
         for at in TAG_ATTRS_TO_TRACK.get(tag.lower(), []):
-            self.links.extend(search_attr(at), attrs)
+            self.links.extend(search_attr(at, attrs))
 
 
 def links_in_srcset(attrval):

--- a/plone/app/linkintegrity/parser.py
+++ b/plone/app/linkintegrity/parser.py
@@ -55,7 +55,7 @@ def search_attr(name, attrs):
             if name == "srcset":
                 # SRCSET is split by commas, and each line's first
                 # element is the URL in question.
-                return [x.strip().split()[0] for x in value.split(",")]
+                return [src.strip().split()[0] for src in value.split(",")]
             else:
                 return [value]
     return []

--- a/plone/app/linkintegrity/parser.py
+++ b/plone/app/linkintegrity/parser.py
@@ -30,9 +30,21 @@ class LinkParser(HTMLParser):
             self.links.extend(search_attr('href', attrs))
         if tag == 'img':
             self.links.extend(search_attr('src', attrs))
+            self.links.extend(search_attr('srcset', attrs))
         if tag == 'source':
+            # Used within img/picture/audio/video tags
+            # to embed various sources of media.
             self.links.extend(search_attr('src', attrs))
             self.links.extend(search_attr('srcset', attrs))
+        if tag == 'audio':
+            # Embeds audio recordings.
+            self.links.extend(search_attr('src', attrs))
+        if tag == 'video':
+            # Embeds videos.
+            self.links.extend(search_attr('src', attrs))
+        if tag == 'iframe':
+            # Used to embed PDFs.
+            self.links.extend(search_attr('src', attrs))
 
 
 def search_attr(name, attrs):
@@ -40,7 +52,12 @@ def search_attr(name, attrs):
     """
     for attr, value in attrs:
         if attr == name:
-            return [value]
+            if name == "srcset":
+                # SRCSET is split by commas, and each line's first
+                # element is the URL in question.
+                return [x.strip().split()[0] for x in value.split(",")]
+            else:
+                return [value]
     return []
 
 


### PR DESCRIPTION
IFRAMEs are commonly used to embed PDFs on site pages.

Uploaded PDFs need to be tracked so link integrity is preserved.

EDIT: code updated to bring feature parity with https://github.com/plone/plone.outputfilters/pull/47