### PR TITLE
Test fix: only load plone.app.contenttypes migration layer on Python 2.

### DIFF
--- a/news/641.bugfix
+++ b/news/641.bugfix
@@ -1,0 +1,2 @@
+Test fix: only load plone.app.contenttypes migration layer on Python 2.
+[maurits]

--- a/plone/app/linkintegrity/testing.py
+++ b/plone/app/linkintegrity/testing.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
-from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE  # noqa
 from plone.app.testing import layers
 from plone.app.testing import login
 from plone.app.testing import PLONE_FIXTURE
@@ -95,29 +94,6 @@ class LinkIntegrityLayer(z2.Layer):
 PLONE_APP_LINKINTEGRITY_FIXTURE = LinkIntegrityLayer()
 
 
-class LinkIntegrityATLayer(LinkIntegrityLayer):
-    """Layer which targets testing with Archetypes and ATContentTypes.
-    """
-
-    directory = 'at'
-    defaultBases = (
-        PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE,
-        PLONE_APP_LINKINTEGRITY_FIXTURE,
-    )
-
-    def setUp(self):
-        self.setUpContent()
-
-    def setUpContent(self):
-        super(LinkIntegrityATLayer, self).setUpContent()
-
-        with ploneSite() as portal:
-            create(portal, 'Image', id='image1', title='Image 1', image=GIF)
-
-
-PLONE_APP_LINKINTEGRITY_AT_FIXTURE = LinkIntegrityATLayer()
-
-
 class LinkIntegrityDXLayer(LinkIntegrityLayer):
     """Layer which targets testing with Dexterity.
     """
@@ -157,6 +133,31 @@ PLONE_APP_LINKINTEGRITY_DX_FUNCTIONAL_TESTING = layers.FunctionalTesting(
 )
 
 if six.PY2:
+    from plone.app.contenttypes.testing import (
+        PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE,
+    )
+
+    class LinkIntegrityATLayer(LinkIntegrityLayer):
+        """Layer which targets testing with Archetypes and ATContentTypes.
+        """
+
+        directory = 'at'
+        defaultBases = (
+            PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE,
+            PLONE_APP_LINKINTEGRITY_FIXTURE,
+        )
+
+        def setUp(self):
+            self.setUpContent()
+
+        def setUpContent(self):
+            super(LinkIntegrityATLayer, self).setUpContent()
+
+            with ploneSite() as portal:
+                create(portal, 'Image', id='image1', title='Image 1', image=GIF)
+
+    PLONE_APP_LINKINTEGRITY_AT_FIXTURE = LinkIntegrityATLayer()
+
     PLONE_APP_LINKINTEGRITY_AT_INTEGRATION_TESTING = layers.IntegrationTesting(
         bases=(PLONE_APP_LINKINTEGRITY_AT_FIXTURE, ),
         name='plone.app.linkintegrity:AT:Integration'


### PR DESCRIPTION
This is needed to fix our failing test setup in combination with https://github.com/plone/plone.app.contenttypes/pull/641
That PR for Plone 6 removes the migration test layer.
Sample [failing test](https://jenkins.plone.org/job/pull-request-6.0-3.9/1136/testReport/junit/plone.app.linkintegrity.tests/test_circular/Startup/):

```
cannot import name 'PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE' from 'plone.app.contenttypes.testing' (/home/jenkins/workspace/pull-request-6.0-3.9/src/plone.app.contenttypes/plone/app/contenttypes/testing.py)

  File "/home/jenkins/.buildout/eggs/cp39/plone.app.linkintegrity-3.6.0-py3.9.egg/plone/app/linkintegrity/tests/test_circular.py", line 3, in <module>
    from plone.app.linkintegrity.testing import create
  File "/home/jenkins/.buildout/eggs/cp39/plone.app.linkintegrity-3.6.0-py3.9.egg/plone/app/linkintegrity/testing.py", line 3, in <module>
    from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_MIGRATION_FIXTURE  # noqa
```
