### PR TITLE
Remove outgoing RelationValues from catalog after deleting content item.

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,2 @@
+Remove outgoing 'isReferencing' RelationValues from catalog on deleting content item.
+[ksuess]

--- a/plone/app/linkintegrity/configure.zcml
+++ b/plone/app/linkintegrity/configure.zcml
@@ -33,6 +33,14 @@
       handler=".handlers.modifiedContent"
       />
 
+  <!-- Not zope.lifecycleevent.interfaces.IObjectRemovedEvent!
+    That's too late to grep the intId. -->
+  <subscriber
+      for="plone.app.relationfield.interfaces.IDexterityHasRelations
+           OFS.interfaces.IObjectWillBeRemovedEvent"
+      handler=".handlers.removedContent"
+      />
+
   <genericsetup:registerProfile
       name="default"
       title="plone.app.linkintegrity"

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -118,8 +118,12 @@ def removedContent(obj, event):
     if not check_linkintegrity_dependencies(obj):
         return
 
-    int_id = ensure_intid(obj)
-    if int_id is None:
+    intids = getUtility(IIntIds, None)
+    if intids is None:
+        return
+    try:
+        int_id = intids.getId(obj)
+    except KeyError:
         return
 
     catalog = getUtility(ICatalog)

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -118,18 +118,13 @@ def removedContent(obj, event):
     if not check_linkintegrity_dependencies(obj):
         return
 
-    intids = getUtility(IIntIds, None)
-    if intids is None:
-        return
+    intids = getUtility(IIntIds)
     try:
         int_id = intids.getId(obj)
     except KeyError:
         return
 
     catalog = getUtility(ICatalog)
-    if catalog is None:
-        return
-
     rels = catalog.findRelations(
         {"from_id": int_id, "from_attribute": referencedRelationship}
     )

--- a/plone/app/linkintegrity/handlers.py
+++ b/plone/app/linkintegrity/handlers.py
@@ -78,7 +78,10 @@ def findObject(base, path):
 
 
 def getObjectsFromLinks(base, links):
-    """determine actual objects referred to by given links"""
+    """Determine actual objects referred to by given links.
+
+    return set of RelationValue
+    """
     intids = getUtility(IIntIds)
     objects = set()
     url = base.absolute_url()
@@ -109,6 +112,25 @@ def modifiedContent(obj, event):
         links = retriever.retrieveLinks()
         refs = getObjectsFromLinks(obj, links)
         updateReferences(obj, refs)
+
+
+def removedContent(obj, event):
+    if not check_linkintegrity_dependencies(obj):
+        return
+
+    int_id = ensure_intid(obj)
+    if int_id is None:
+        return
+
+    catalog = getUtility(ICatalog)
+    if catalog is None:
+        return
+
+    rels = catalog.findRelations(
+        {"from_id": int_id, "from_attribute": referencedRelationship}
+    )
+    for rel in list(rels):
+        catalog.unindex(rel)
 
 
 # BBB

--- a/plone/app/linkintegrity/tests/test_references.py
+++ b/plone/app/linkintegrity/tests/test_references.py
@@ -146,7 +146,8 @@ class ReferenceGenerationTestCase(unittest.TestCase):
         set_text(doc_temp, '<a href="doc1">Doc 1</a>')
         self.assertEqual(len(list(getIncomingLinks(doc1))), 1)
         self.assertEqual(
-            [link.from_object for link in getIncomingLinks(doc1)], [self.portal.doc_temp]
+            [link.from_object for link in getIncomingLinks(doc1)],
+            [self.portal.doc_temp],
         )
 
         catalog = getUtility(ICatalog)

--- a/plone/app/linkintegrity/tests/test_references.py
+++ b/plone/app/linkintegrity/tests/test_references.py
@@ -137,6 +137,32 @@ class ReferenceGenerationTestCase(unittest.TestCase):
             _marker = dict()
             self.assertEqual(getattr(obj, "aq_parent", _marker), _marker)
 
+    def test_catalog_cleaned_up(self):
+        doc1 = self.portal.doc1
+        # Create a temporary document to test with.
+        doc_temp = testing.create(self.portal, "Document", id="doc_temp")
+
+        self.assertEqual(len(list(getIncomingLinks(doc1))), 0)
+        set_text(doc_temp, '<a href="doc1">Doc 1</a>')
+        self.assertEqual(len(list(getIncomingLinks(doc1))), 1)
+        self.assertEqual(
+            [link.from_object for link in getIncomingLinks(doc1)], [self.portal.doc_temp]
+        )
+
+        catalog = getUtility(ICatalog)
+        rels = list(catalog.findRelations())
+        self.assertEqual(len(rels), 1)
+
+        # Now delete the source item.
+        self.portal._delObject(doc_temp.id)
+
+        # Test, if relation is removed from the relation catalog.
+        catalog = getUtility(ICatalog)
+        rels = list(catalog.findRelations())
+        self.assertEqual(len(rels), 0)
+
+        self.assertEqual(len(list(getIncomingLinks(doc1))), 0)
+
     def test_relative_upwards_link_generates_matching_reference(self):
         doc1 = self.portal.doc1
         doc3 = self.portal.folder1.doc3


### PR DESCRIPTION
ingoing RelationValues are unindexed in updateRelations of z3c.relationfield.